### PR TITLE
feat: add /분배금정산 command (Notion 연동)

### DIFF
--- a/commands/calculate_distribution.py
+++ b/commands/calculate_distribution.py
@@ -1,0 +1,85 @@
+from datetime import datetime, date
+import discord
+from discord import app_commands
+from discord.ext import commands
+from notion_client import Client
+import os
+
+NOTION_API_KEY = os.getenv("NOTION_API_KEY")
+NOTION_DB_ID = os.getenv("NOTION_DISTRIBUTION_DB_ID")
+
+notion = Client(auth=NOTION_API_KEY)
+
+
+def parse_number(prop):
+    return prop.get("number")
+
+
+def parse_date(prop):
+    if prop.get("date") and prop["date"].get("start"):
+        return datetime.fromisoformat(prop["date"]["start"]).date()
+    return None
+
+
+def parse_text(prop):
+    arr = prop.get("title") or prop.get("rich_text", [])
+    return "".join([x.get("plain_text", "") for x in arr]) if arr else ""
+
+
+def query_by_date(target_date: date):
+    res = notion.databases.query(
+        database_id=NOTION_DB_ID,
+        filter={"property": "날짜", "date": {
+            "on_or_after": target_date.isoformat(),
+            "on_or_before": target_date.isoformat()
+        }},
+        page_size=1
+    )
+    return res.get("results", [])
+
+
+def extract_page_info(page):
+    props = page["properties"]
+    return {
+        "date": parse_date(props["날짜"]),
+        "title": parse_text(props["정산 세부 페이지"]),
+        "status": props["정산진행 여부"]["status"]["name"] if props.get("정산진행 여부") else "",
+        "participants": parse_number(props["참여자 수"]),
+        "total": parse_number(props["총 수익"]),
+        "per_person": parse_number(props["인당 분배금"]),
+        "url": page.get("url")
+    }
+
+
+def setup_distribution_command(bot: commands.Bot):
+    @bot.tree.command(name="분배금정산", description="노션 DB에서 정산 정보를 불러옵니다.")
+    @app_commands.describe(날짜="YYYY-MM-DD 형식 (예: 2025-07-27)")
+    async def distribution(interaction: discord.Interaction, 날짜: str):
+        await interaction.response.defer(ephemeral=True)
+
+        try:
+            y, m, d = map(int, 날짜.split("-"))
+            target_date = date(y, m, d)
+        except ValueError:
+            await interaction.followup.send("날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)", ephemeral=True)
+            return
+
+        pages = query_by_date(target_date)
+        if not pages:
+            await interaction.followup.send("해당 날짜의 정산 정보를 찾을 수 없습니다.", ephemeral=True)
+            return
+
+        page_info = extract_page_info(pages[0])
+
+        embed = discord.Embed(
+            title=f"정산 — {page_info['title']}",
+            url=page_info["url"],
+            color=discord.Color.green()
+        )
+        embed.add_field(name="날짜", value=str(page_info["date"]), inline=True)
+        embed.add_field(name="정산 상태", value=page_info["status"], inline=True)
+        embed.add_field(name="참여자 수", value=str(page_info["participants"]), inline=True)
+        embed.add_field(name="총 수익", value=f"{page_info['total']:,}원", inline=True)
+        embed.add_field(name="인당 분배금", value=f"{page_info['per_person']:,}원", inline=True)
+
+        await interaction.followup.send(embed=embed, ephemeral=True)

--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ from commands.reaction_handler import setup_reaction_handler
 from commands.edit_schedule import setup_edit_raid_command
 from commands.show_schdule import setup_show_raids_command
 from commands.delete_schedule import setup_delete_raid_command
+from commands.calculate_distribution import setup_distribution_command  # ← 추가
+
 from tasks import reminder
 from views.raid_controls import RaidControlView
 
@@ -27,6 +29,7 @@ setup_reaction_handler(bot)
 setup_edit_raid_command(bot)
 setup_show_raids_command(bot)
 setup_delete_raid_command(bot)
+setup_distribution_command(bot)
 
 
 # health check endpoint

--- a/poetry.lock
+++ b/poetry.lock
@@ -686,6 +686,21 @@ files = [
 typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "notion-client"
+version = "2.4.0"
+description = "Python client for the official Notion API"
+optional = false
+python-versions = "<4,>=3.7"
+groups = ["main"]
+files = [
+    {file = "notion_client-2.4.0-py2.py3-none-any.whl", hash = "sha256:89f47c0a5eedc08f1170c04e85f422091ce3e095f20b69a3877152e875f0094f"},
+    {file = "notion_client-2.4.0.tar.gz", hash = "sha256:e7ff32f733fdbe0f18a37f5d98ff665681e5b3c4dcf2faa6e602bb1b16a3b15d"},
+]
+
+[package.dependencies]
+httpx = ">=0.23.0"
+
+[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
@@ -1344,4 +1359,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "0b927ca465f2f5f09bec99bddcbbf6819ac2b5eac8e9a46a23285809d3e5146c"
+content-hash = "a372f49b8c47ccd9402c7a9126cd4cce3d6f8ab175b4be16eaa17314ee9335db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ requires-python = ">=3.9,<4.0"
 dependencies = [
     "discord-py (>=2.5.2,<3.0.0)",
     "python-dotenv (>=1.1.1,<2.0.0)",
-    "supabase (>=2.17.0,<3.0.0)"
+    "supabase (>=2.17.0,<3.0.0)",
+    "notion-client (>=2.4.0,<3.0.0)"
 ]
 
 


### PR DESCRIPTION
## 개요
- Notion 정산 데이터베이스에서 날짜별 정산 정보를 불러와 Discord Embed로 출력하는 `/분배금정산` 명령어 추가

## 변경 사항
- commands/calculate_distribution.py 신규 추가
- main.py에 `/분배금정산` 명령어 등록 로직 추가
- 환경 변수 `NOTION_API_KEY`, `NOTION_DISTRIBUTION_DB_ID` 사용

## 실행 예시
- `/분배금정산 2025-07-27`
  - 정산 날짜, 상태, 참여자 수, 총 수익, 인당 분배금 표시

## 참고
- notion-client 패키지 신규 의존성 추가
- Koyeb 배포 전 환경 변수 설정 필요
