### PR TITLE
refactor: KST 파싱 유틸 공통화 및 삭제/수정 명령어에서 ‘앞으로의 일정만’ 노출

### DIFF
--- a/commands/delete_schedule.py
+++ b/commands/delete_schedule.py
@@ -1,4 +1,6 @@
 import os
+from datetime import datetime
+from utils.datetime_util import parse_kst, KST
 
 import discord
 from discord.ext import commands
@@ -15,11 +17,14 @@ def setup_delete_raid_command(bot: commands.Bot):
             return
 
         raids = get_all_raids()
-        if not raids:
+        now = datetime.now(KST)
+        upcoming_raids = [r for r in raids if parse_kst(r["datetime"]) >= now]
+
+        if not upcoming_raids:
             await interaction.response.send_message("⚠️ 삭제할 일정이 없습니다.", ephemeral=True)
             return
 
-        sorted_raids = sorted(raids, key=lambda r: r["datetime"], reverse=True)
+        sorted_raids = sorted(upcoming_raids, key=lambda r: r["datetime"])
         options = [discord.SelectOption(label=raid["datetime"], value=raid["datetime"]) for raid in sorted_raids[:25]]
 
         class DeleteDropdown(discord.ui.Select):

--- a/commands/edit_schedule.py
+++ b/commands/edit_schedule.py
@@ -1,9 +1,10 @@
 import os
+from datetime import datetime
+from utils.datetime_util import parse_kst, KST
 
 import discord
 from discord.ext import commands
 from supabase_storage import get_all_raids, get_raid_by_key, update_raid
-from datetime import datetime
 
 RAID_ANNOUNCEMENT_CHANNEL_ID = int(os.getenv("RAID_ANNOUNCEMENT_CHANNEL_ID"))
 
@@ -139,11 +140,14 @@ def setup_edit_raid_command(bot: commands.Bot):
             await interaction.response.send_message("❌ 관리자만 사용할 수 있습니다.", ephemeral=True)
             return
 
-        if not raids:
+        now = datetime.now(KST)
+        upcoming_raids = [r for r in raids if parse_kst(r["datetime"]) >= now]
+
+        if not upcoming_raids:
             await interaction.response.send_message("⚠️ 수정할 일정이 없습니다.", ephemeral=True)
             return
 
-        sorted_raids = sorted(raids, key=lambda r: r["datetime"], reverse=True)
+        sorted_raids = sorted(upcoming_raids, key=lambda r: r["datetime"])
         options = [
             discord.SelectOption(label=raid["datetime"], value=raid["datetime"])
             for raid in sorted_raids[:25]

--- a/commands/show_schdule.py
+++ b/commands/show_schdule.py
@@ -1,18 +1,9 @@
 from datetime import datetime
-from zoneinfo import ZoneInfo
+from utils.datetime_util import parse_kst, KST
 
 import discord
 from discord.ext import commands
 from supabase_storage import get_all_raids  # Supabase 연동 함수 import
-
-
-KST = ZoneInfo("Asia/Seoul")
-
-
-def _parse_kst(dt_str: str) -> datetime:
-    """ISO 문자열을 KST로 파싱 (naive면 KST tz 부여)"""
-    dt = datetime.fromisoformat(dt_str)  # "YYYY-MM-DD HH:MM" or ISO8601
-    return dt if dt.tzinfo else dt.replace(tzinfo=KST)
 
 
 def setup_show_raids_command(bot: commands.Bot):
@@ -21,13 +12,13 @@ def setup_show_raids_command(bot: commands.Bot):
         raids = get_all_raids()
         now = datetime.now(KST)
 
-        upcoming = [r for r in raids if _parse_kst(r["datetime"]) >= now]
+        upcoming = [r for r in raids if parse_kst(r["datetime"]) >= now]
 
         if not upcoming:
             await interaction.response.send_message("📭 앞으로 예정된 일정이 없습니다.", ephemeral=True)
             return
 
-        sorted_raids = sorted(upcoming, key=lambda r: _parse_kst(r["datetime"]))
+        sorted_raids = sorted(upcoming, key=lambda r: parse_kst(r["datetime"]))
 
         embed = discord.Embed(title="📋 자쿰 일정 목록", color=discord.Color.blurple())
         embed.description = ""

--- a/utils/datetime_util.py
+++ b/utils/datetime_util.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def parse_kst(dt_str: str) -> datetime:
+    """
+    ISO 문자열을 KST로 파싱 (naive면 KST tz 부여)
+    예) "2025-08-12 13:30" 또는 "2025-08-12T13:30:00"
+    """
+    dt = datetime.fromisoformat(dt_str)
+    return dt if dt.tzinfo else dt.replace(tzinfo=KST)


### PR DESCRIPTION
## 개요
- 날짜/시간 파싱 로직을 공통 유틸로 분리하고, `/일정삭제`, `/일정수정`에서도 앞으로의 일정만 선택하도록 정리했습니다.
- 타임존(KST) 기준의 일관된 비교를 보장합니다.

## 변경 내용
- utils/datetime_utils.py 추가
  - `KST = ZoneInfo("Asia/Seoul")`
  - `parse_kst(dt_str: str) -> datetime` (naive → KST 부여, aware는 그대로)
- show_schedule.py
  - 공통 유틸 사용(`parse_kst`, `KST`)
- delete_schedule.py
  - `get_all_raids()` 결과에서 `parse_kst(r["datetime"]) >= now(KST)`인 **앞으로의 일정만** 드롭다운 노출
  - 공통 유틸 사용
- edit_schedule.py
  - `get_all_raids()` 결과에서 `parse_kst(r["datetime"]) >= now(KST)`인 **앞으로의 일정만** 드롭다운 노출
  - 공통 유틸 사용

## 이유
- 중복된 KST 파싱 로직을 한 곳에서 관리하여 유지보수성 향상
- 과거 일정 선택으로 인한 실수 방지 (삭제/수정 시 미래 일정만 표시)
- naive/aware datetime 혼용으로 생길 수 있는 비교 오류 예방

## 테스트
- 로컬 테스트 서버에서 아래 확인
  - 과거/미래 일정 혼재 시: `/일정확인`은 미래만 표기, `/일정삭제`, `/일정수정` 드롭다운에도 미래 일정만 노출
  - naive 포맷(`"YYYY-MM-DD HH:MM"`)과 ISO 포맷 모두 파싱 정상
  - 권한 없는 유저는 여전히 실행 불가(ephemeral 안내)

## 영향 범위
- 런타임 환경변수/마이그레이션 없음
- 기존 데이터 포맷(문자열 ISO) 그대로 호환

## 체크리스트
- [x] 기능 동작 수동 확인
- [x] 타임존/KST 비교 일관성 보장
- [x] 코드 중복 제거 및 모듈화
