### PR TITLE
fix(reminder): KST aware + window 기반 판정으로 1h/24h 알림 누락/중복 방지

### DIFF
--- a/tasks/reminder.py
+++ b/tasks/reminder.py
@@ -3,15 +3,27 @@ from datetime import datetime, timedelta
 from supabase_storage import get_all_raids
 from zoneinfo import ZoneInfo
 
-
 bot = None  # 전역 변수로 봇 인스턴스 저장
-
 KST = ZoneInfo("Asia/Seoul")
+
+# 직전 루프 시각(알림 중복/누락 방지용)
+_last_tick: datetime | None = None
 
 
 def set_bot_instance(bot_instance):
     global bot
     bot = bot_instance
+
+
+async def _get_user(uid: int):
+    """유저 캐시 미스 보완."""
+    user = bot.get_user(uid)
+    if user is None:
+        try:
+            user = await bot.fetch_user(uid)
+        except Exception:
+            return None
+    return user
 
 
 async def send_raid_reminder(raid, message_type):
@@ -20,20 +32,39 @@ async def send_raid_reminder(raid, message_type):
         return
 
     for uid in participants:
-        user = bot.get_user(int(uid))
-        if user:
-            try:
-                await user.send(f"🔔 **{message_type}** 알림입니다!\n자쿰 공대({raid['datetime']})에 참여 예정이에요!")
-            except Exception as e:
-                print(f"❌ {uid}님에게 DM 보내기 실패: {e}")
-        else:
-            print(f"❌ 유저 {uid} 찾을 수 없음")
+        try:
+            user = await _get_user(int(uid))
+            if not user:
+                print(f"[reminder] 유저 {uid}를 찾을 수 없음")
+                continue
+            await user.send(
+                f"🔔 **{message_type}**\n"
+                f"자쿰 공대 **{raid['datetime']}** 에 참여 예정이에요!"
+            )
+        except Exception as e:
+            print(f"[reminder] DM 실패 uid={uid}: {e}")
 
 
 @tasks.loop(minutes=5)
 async def check_upcoming_raids():
-    raids = get_all_raids()
-    now = datetime.now()
+    global _last_tick
+
+    now = datetime.now(KST)
+    # 첫 루프에서는 기준점만 잡고 종료 (다음 루프부터 판정)
+    if _last_tick is None:
+        _last_tick = now
+        return
+
+    window_start = _last_tick
+    window_end = now
+    _last_tick = now
+
+    # 최신 일정 조회
+    try:
+        raids = get_all_raids()
+    except Exception as e:
+        print(f"[reminder] 일정 조회 실패: {e}")
+        return
 
     for raid in raids:
         try:
@@ -41,12 +72,18 @@ async def check_upcoming_raids():
         except ValueError:
             continue
 
-        # 1시간 전 알림 (±2.5분)
-        seconds_left = (raid_time - now).total_seconds()
-        if 3600 <= seconds_left < 3600 + 300:
+        t_minus_1h  = raid_time - timedelta(hours=1)
+        t_minus_24h = raid_time - timedelta(hours=24)
+
+        # 지난 루프~이번 루프 사이에 목표시각을 '통과'했으면 발송
+        if window_start <= t_minus_1h < window_end:
             await send_raid_reminder(raid, "공대 시작 1시간 전")
 
-        # 24시간 전 알림
-        target = raid_time - timedelta(hours=24)
-        if target <= now < target + timedelta(minutes=5):
+        if window_start <= t_minus_24h < window_end:
             await send_raid_reminder(raid, "공대 시작 24시간 전")
+
+
+# 루프 에러 핸들러(예외로 루프 정지 방지)
+@check_upcoming_raids.error
+async def _reminder_error(e):
+    print(f"[reminder] loop error: {e}")


### PR DESCRIPTION
## 개요
알림이 간헐적으로 누락/중복되는 문제를 해결했습니다. 
시간대 혼용(naive vs aware)과 루프 타이밍 의존(±2.5분 윈도우) 때문에 발생하던 이슈를 KST 기준의 aware datetime과 "루프 구간 통과" 방식으로 안정화했습니다.

## 변경 사항
- now를 `datetime.now(KST)`로 통일하여 KST aware 시각 사용
- 알림 판정 로직을 "지난 루프~현재 루프 사이에 목표 시각을 통과했는가"로 변경  
  - `t_minus_1h = raid_time - 1h`  
  - `t_minus_24h = raid_time - 24h`  
  - `window_start <= target < window_end` → 트리거
- 첫 루프에서는 `_last_tick` 기준점만 설정하여 과거 이벤트에 대해 오발송 방지
- `@check_upcoming_raids.error` 핸들러 추가 (예외 발생 시 루프 중단 방지)
- DM 전송 시 `get_user` 캐시 미스면 `fetch_user`로 보완, 실패 로깅 개선

## 왜 이렇게 바꿨나
- 기존 ±2.5분 오차 판정은 루프 실행 시각(5분 간격)과 미세한 지연에 취약 → 알림 누락/중복
- naive(now) vs aware(raid_time) 비교는 예외 및 오동작 유발
- 예외 발생 시 루프가 멈춰 이후 알림이 전혀 나가지 않는 문제 가능

## 기대 효과 (Before → After)
- (Before) 루프 타이밍에 따라 1시간 전/24시간 전 알림이 종종 누락됨  
- (After) 루프 구간을 지나는 순간 정확히 한 번만 발송 → 누락/중복 해소
- (Before) 예외 발생 시 루프 중단 위험  
- (After) 에러 핸들러로 안전하게 복구/로깅

## 테스트
- 루프 간격을 임시로 `seconds=10`으로 낮춘 뒤, 가까운 시각에 레이드 생성하여 1h/24h 타겟을 단축 테스트
- 과거/미래 일정 혼재 상태에서 과거 알림 비발송, 미래 알림 정상 발송 확인
- DM 전송 실패/미가입 사용자 등 에러 케이스 로깅 확인
- 실제 KST 환경에서 날짜 경계(자정 전후) 정상 동작 확인

## 영향 범위
- `tasks/reminder.py` 내부 로직 변경. 외부 API/스키마 변경 없음.
- `main.py`의 루프 시작(`reminder.check_upcoming_raids.start()`) 방식은 그대로 사용.


## 체크리스트
- [x] KST aware 비교 일관성
- [x] 누락/중복 알림 재현 불가
- [x] 예외 발생 시 루프 지속 동작
- [x] 로깅으로 장애 원인 추적 가능
