### PR TITLE
Fix reminders: use KST-aware window crossing and add robust logging

### DIFF
--- a/tasks/reminder.py
+++ b/tasks/reminder.py
@@ -1,13 +1,17 @@
-from discord.ext import tasks
 from datetime import datetime, timedelta
-from supabase_storage import get_all_raids
 from zoneinfo import ZoneInfo
+from discord.ext import tasks
+
+from supabase_storage import get_all_raids
 
 bot = None  # 전역 변수로 봇 인스턴스 저장
 KST = ZoneInfo("Asia/Seoul")
 
 # 직전 루프 시각(알림 중복/누락 방지용)
 _last_tick: datetime | None = None
+
+# 디버그 로그 토글 (원하면 환경변수로도 제어 가능)
+DEBUG = True
 
 
 def set_bot_instance(bot_instance):
@@ -29,6 +33,8 @@ async def _get_user(uid: int):
 async def send_raid_reminder(raid, message_type):
     participants = raid.get("participants", [])
     if not participants:
+        if DEBUG:
+            print(f"[reminder] skip: participants empty for {raid.get('datetime')}")
         return
 
     for uid in participants:
@@ -41,23 +47,33 @@ async def send_raid_reminder(raid, message_type):
                 f"🔔 **{message_type}**\n"
                 f"자쿰 공대 **{raid['datetime']}** 에 참여 예정이에요!"
             )
+            if DEBUG:
+                print(f"[reminder] DM sent to {uid} ({message_type})")
+
         except Exception as e:
             print(f"[reminder] DM 실패 uid={uid}: {e}")
 
 
 @tasks.loop(minutes=5)
 async def check_upcoming_raids():
+    """지난 루프~이번 루프 사이에 '목표시각을 통과'했으면 알림 발송."""
     global _last_tick
 
     now = datetime.now(KST)
+
     # 첫 루프에서는 기준점만 잡고 종료 (다음 루프부터 판정)
     if _last_tick is None:
         _last_tick = now
+        if DEBUG:
+            print(f"[reminder] first tick; anchor set to {now.isoformat()}")
         return
 
     window_start = _last_tick
     window_end = now
     _last_tick = now
+
+    if DEBUG:
+        print(f"[reminder] window {window_start.isoformat()} → {window_end.isoformat()}")
 
     # 최신 일정 조회
     try:
@@ -69,17 +85,21 @@ async def check_upcoming_raids():
     for raid in raids:
         try:
             raid_time = datetime.strptime(raid["datetime"], "%Y-%m-%d %H:%M").replace(tzinfo=KST)
-        except ValueError:
+        except Exception as e:
+            print(f"[reminder] bad datetime ({raid.get('datetime')}): {e}")
             continue
 
-        t_minus_1h  = raid_time - timedelta(hours=1)
-        t_minus_24h = raid_time - timedelta(hours=24)
+        t1h = raid_time - timedelta(hours=1)
+        t24h = raid_time - timedelta(hours=24)
 
-        # 지난 루프~이번 루프 사이에 목표시각을 '통과'했으면 발송
-        if window_start <= t_minus_1h < window_end:
+        if DEBUG:
+            print(f"[reminder] raid={raid['datetime']} t-1h={t1h.time()} t-24h={t24h.time()} participants={len(raid.get('participants', []))}")
+
+        # 지난 루프~이번 루프 사이를 '통과'했는지로 판정 (루프 타이밍/지연 무관)
+        if window_start <= t1h < window_end:
             await send_raid_reminder(raid, "공대 시작 1시간 전")
 
-        if window_start <= t_minus_24h < window_end:
+        if window_start <= t24h < window_end:
             await send_raid_reminder(raid, "공대 시작 24시간 전")
 
 

--- a/tasks/reminder.py
+++ b/tasks/reminder.py
@@ -3,15 +3,27 @@ from datetime import datetime, timedelta
 from supabase_storage import get_all_raids
 from zoneinfo import ZoneInfo
 
-
 bot = None  # 전역 변수로 봇 인스턴스 저장
-
 KST = ZoneInfo("Asia/Seoul")
+
+# 직전 루프 시각(알림 중복/누락 방지용)
+_last_tick: datetime | None = None
 
 
 def set_bot_instance(bot_instance):
     global bot
     bot = bot_instance
+
+
+async def _get_user(uid: int):
+    """유저 캐시 미스 보완."""
+    user = bot.get_user(uid)
+    if user is None:
+        try:
+            user = await bot.fetch_user(uid)
+        except Exception:
+            return None
+    return user
 
 
 async def send_raid_reminder(raid, message_type):
@@ -20,20 +32,39 @@ async def send_raid_reminder(raid, message_type):
         return
 
     for uid in participants:
-        user = bot.get_user(int(uid))
-        if user:
-            try:
-                await user.send(f"🔔 **{message_type}** 알림입니다!\n자쿰 공대({raid['datetime']})에 참여 예정이에요!")
-            except Exception as e:
-                print(f"❌ {uid}님에게 DM 보내기 실패: {e}")
-        else:
-            print(f"❌ 유저 {uid} 찾을 수 없음")
+        try:
+            user = await _get_user(int(uid))
+            if not user:
+                print(f"[reminder] 유저 {uid}를 찾을 수 없음")
+                continue
+            await user.send(
+                f"🔔 **{message_type}**\n"
+                f"자쿰 공대 **{raid['datetime']}** 에 참여 예정이에요!"
+            )
+        except Exception as e:
+            print(f"[reminder] DM 실패 uid={uid}: {e}")
 
 
 @tasks.loop(minutes=5)
 async def check_upcoming_raids():
-    raids = get_all_raids()
-    now = datetime.now()
+    global _last_tick
+
+    now = datetime.now(KST)
+    # 첫 루프에서는 기준점만 잡고 종료 (다음 루프부터 판정)
+    if _last_tick is None:
+        _last_tick = now
+        return
+
+    window_start = _last_tick
+    window_end = now
+    _last_tick = now
+
+    # 최신 일정 조회
+    try:
+        raids = get_all_raids()
+    except Exception as e:
+        print(f"[reminder] 일정 조회 실패: {e}")
+        return
 
     for raid in raids:
         try:
@@ -41,12 +72,18 @@ async def check_upcoming_raids():
         except ValueError:
             continue
 
-        # 1시간 전 알림 (±2.5분)
-        seconds_left = (raid_time - now).total_seconds()
-        if 3600 <= seconds_left < 3600 + 300:
+        t_minus_1h  = raid_time - timedelta(hours=1)
+        t_minus_24h = raid_time - timedelta(hours=24)
+
+        # 지난 루프~이번 루프 사이에 목표시각을 '통과'했으면 발송
+        if window_start <= t_minus_1h < window_end:
             await send_raid_reminder(raid, "공대 시작 1시간 전")
 
-        # 24시간 전 알림
-        target = raid_time - timedelta(hours=24)
-        if target <= now < target + timedelta(minutes=5):
+        if window_start <= t_minus_24h < window_end:
             await send_raid_reminder(raid, "공대 시작 24시간 전")
+
+
+# 루프 에러 핸들러(예외로 루프 정지 방지)
+@check_upcoming_raids.error
+async def _reminder_error(e):
+    print(f"[reminder] loop error: {e}")


### PR DESCRIPTION
## 변경 내용
- KST aware 시간 비교로 통일 (datetime.now(KST))
- 지난 루프~현재 루프 구간을 통과했는지로 1시간/24시간 전 알림 트리거
- 루프 에러 핸들러 추가로 예외 시에도 작업 지속
- 디버그 로그 추가(윈도우/레이드 시각/참여자 수/DM 결과)

## 왜 필요한가
- 기존 ±2.5분 판정은 루프 타이밍에 따라 누락/중복 발생
- naive/aware 혼용으로 비교 예외 및 루프 중단 위험

## 테스트
- 루프 간격 단축 후(10s) 근접 타겟으로 검증
- 참가자 없는 일정은 스킵되는 것 확인
- KST 기준 자정 전후 시나리오 정상 동작